### PR TITLE
Standardize the GameMode prop for all Chaos armies

### DIFF
--- a/Battleforged Mod Pack/Warhammer 40,000/Army Collections/Armies of Chaos/Chaos Knights/TS_Save_64.json
+++ b/Battleforged Mod Pack/Warhammer 40,000/Army Collections/Armies of Chaos/Chaos Knights/TS_Save_64.json
@@ -1,9 +1,9 @@
 {
   "SaveName": "Chaos Knights - Collection",
+  "GameMode": "Warhammer 40k - Chaos Knights",
   "EpochTime": 1652834984,
   "Date": "5/17/2022 9:49:44 PM",
-  "VersionNumber": "v13.1.1",
-  "GameMode": "Flex Table",
+  "VersionNumber": "v13.1.1",  
   "GameType": "",
   "GameComplexity": "",
   "Tags": [],

--- a/Battleforged Mod Pack/Warhammer 40,000/Army Collections/Armies of Chaos/Chaos Space Marines/TS_Save_2160.json
+++ b/Battleforged Mod Pack/Warhammer 40,000/Army Collections/Armies of Chaos/Chaos Space Marines/TS_Save_2160.json
@@ -1,9 +1,9 @@
 {
   "SaveName": "All Legions - Forge World Units",
+  "GameMode": "Warhammer 40k - Chaos: All Legions",
   "EpochTime": 1629808269,
   "Date": "8/24/2021 8:31:09 AM",
-  "VersionNumber": "v13.1.1",
-  "GameMode": "Flex Table",
+  "VersionNumber": "v13.1.1",  
   "GameType": "",
   "GameComplexity": "",
   "Tags": [],

--- a/Battleforged Mod Pack/Warhammer 40,000/Army Collections/Armies of Chaos/Chaos Space Marines/TS_Save_61.json
+++ b/Battleforged Mod Pack/Warhammer 40,000/Army Collections/Armies of Chaos/Chaos Space Marines/TS_Save_61.json
@@ -1,9 +1,9 @@
 {
   "SaveName": "Black Legion/Chaos Undivided - Complete Collection + Unique CSM Models",
+  "GameMode": "Warhammer 40k - Chaos: Black Legion/Chaos Undivided",
   "EpochTime": 1647987382,
   "Date": "3/22/2022 7:16:22 PM",
-  "VersionNumber": "v13.1.1",
-  "GameMode": "Dark Angels 8ed Table",
+  "VersionNumber": "v13.1.1",  
   "GameType": "",
   "GameComplexity": "",
   "Tags": [],

--- a/Battleforged Mod Pack/Warhammer 40,000/Army Collections/Armies of Chaos/Chaos Space Marines/TS_Save_62.json
+++ b/Battleforged Mod Pack/Warhammer 40,000/Army Collections/Armies of Chaos/Chaos Space Marines/TS_Save_62.json
@@ -1,9 +1,9 @@
 {
   "SaveName": "Death Guard - Complete Collection",
+  "GameMode": "Warhammer 40k - Chaos: Death Guard",
   "EpochTime": 1635789877,
   "Date": "11/1/2021 2:04:37 PM",
-  "VersionNumber": "v13.1.1",
-  "GameMode": "Dark Angels 8ed Table",
+  "VersionNumber": "v13.1.1",  
   "GameType": "",
   "GameComplexity": "",
   "Tags": [],

--- a/Battleforged Mod Pack/Warhammer 40,000/Army Collections/Armies of Chaos/Chaos Space Marines/TS_Save_63.json
+++ b/Battleforged Mod Pack/Warhammer 40,000/Army Collections/Armies of Chaos/Chaos Space Marines/TS_Save_63.json
@@ -1,9 +1,9 @@
 {
   "SaveName": "Thousand Sons - Complete Collection",
+  "GameMode": "Warhammer 40k - Chaos: Thousand Sons",
   "EpochTime": 1635789437,
   "Date": "11/1/2021 1:57:17 PM",
-  "VersionNumber": "v13.1.1",
-  "GameMode": "Dark Angels 8ed Table",
+  "VersionNumber": "v13.1.1",  
   "GameType": "",
   "GameComplexity": "",
   "Tags": [],

--- a/Battleforged Mod Pack/Warhammer 40,000/Army Collections/Armies of Chaos/Chaos Space Marines/TS_Save_67.json
+++ b/Battleforged Mod Pack/Warhammer 40,000/Army Collections/Armies of Chaos/Chaos Space Marines/TS_Save_67.json
@@ -1,6 +1,6 @@
 {
   "SaveName": "World Eaters - Collection",
-  "GameMode": "The Kraken Table",
+  "GameMode": "Warhammer 40k - Chaos: World Eaters",
   "Date": "2/27/2021 6:12:43 PM",
   "VersionNumber": "v13.0.5",
   "GameType": "",

--- a/Battleforged Mod Pack/Warhammer 40,000/Army Collections/Armies of Chaos/Chaos Space Marines/TS_Save_68.json
+++ b/Battleforged Mod Pack/Warhammer 40,000/Army Collections/Armies of Chaos/Chaos Space Marines/TS_Save_68.json
@@ -1,6 +1,6 @@
 {
   "SaveName": "Emperor's Children - Collection",
-  "GameMode": "Warhammer 40k Space Marines (blood angels supplement)",
+  "GameMode": "Warhammer 40k - Chaos: Emperor's Children",
   "Date": "2/27/2021 6:15:27 PM",
   "VersionNumber": "v13.0.5",
   "GameType": "",

--- a/Battleforged Mod Pack/Warhammer 40,000/Army Collections/Armies of Chaos/Deamons/TS_Save_65.json
+++ b/Battleforged Mod Pack/Warhammer 40,000/Army Collections/Armies of Chaos/Deamons/TS_Save_65.json
@@ -1,9 +1,9 @@
 {
   "SaveName": "Daemons - Complete Collection",
+  "GameMode": "Warhammer 40k - Chaos: Daemons",
   "EpochTime": 1650226628,
   "Date": "4/17/2022 5:17:08 PM",
-  "VersionNumber": "v13.1.1",
-  "GameMode": "Flex Table",
+  "VersionNumber": "v13.1.1",  
   "GameType": "",
   "GameComplexity": "",
   "Tags": [],

--- a/Battleforged Mod Pack/Warhammer 40,000/Army Collections/Armies of Chaos/Renegades/TS_Save_2093.json
+++ b/Battleforged Mod Pack/Warhammer 40,000/Army Collections/Armies of Chaos/Renegades/TS_Save_2093.json
@@ -1,6 +1,6 @@
 {
   "SaveName": "Renegades and Heretics",
-  "GameMode": "Renegades and Heretics - 8e",
+  "GameMode": "Warhammer 40k - Chaos: Renegades and Heretics",
   "Gravity": 0.5,
   "PlayArea": 0.5,
   "Date": "3/28/2020 9:03:41 PM",

--- a/Battleforged Mod Pack/Warhammer 40,000/Army Collections/Armies of Chaos/Servants of the Abyss + Gellerpox/TS_Save_66.json
+++ b/Battleforged Mod Pack/Warhammer 40,000/Army Collections/Armies of Chaos/Servants of the Abyss + Gellerpox/TS_Save_66.json
@@ -1,9 +1,9 @@
 {
   "SaveName": "Servants of the Abyss and Gellarpox Infected - Complete Collection",
+  "GameMode": "Warhammer 40k - Chaos: Servants of the Abyss and Gellarpox Infected",
   "EpochTime": 1620456805,
   "Date": "5/8/2021 2:53:25 AM",
-  "VersionNumber": "v13.1.1",
-  "GameMode": "Flex Table",
+  "VersionNumber": "v13.1.1",  
   "GameType": "",
   "GameComplexity": "",
   "Tags": [],

--- a/Battleforged Mod Pack/Warhammer 40,000/Army Collections/Armies of Chaos/Titanicus Tratoris/TS_Save_2112.json
+++ b/Battleforged Mod Pack/Warhammer 40,000/Army Collections/Armies of Chaos/Titanicus Tratoris/TS_Save_2112.json
@@ -1,9 +1,9 @@
 {
   "SaveName": "Traitoris Titanicus",
+  "GameMode": "Warhammer 40k - Chaos: Traitoris Titanicus",
   "EpochTime": 1625345077,
   "Date": "7/3/2021 4:44:37 PM",
   "VersionNumber": "v13.1.1",
-  "GameMode": "Flex Table",
   "GameType": "",
   "GameComplexity": "",
   "Tags": [],


### PR DESCRIPTION
This PR standardizes the `GameMode` property across the 40K Chaos armies in order to have a consistent value.


![Screenshot 2023-04-18 231335](https://user-images.githubusercontent.com/697518/232907919-706056f8-bbd0-4214-b8fa-ba6719b80728.png)

If you are interested I can go through the rest of the armies in the mod pack and open a few more PRs.